### PR TITLE
Show 'removed' rate plans if they are relevant or post-dated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 subscription-viewer.iml
 cannedDataForTheTrain.js
+Archive.zip

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Zuora Subscription Viewer",
   "description": "This extension creates a visualisation of a Zuora subscription to aid understanding of what's going on for the customer.",
-  "version": "1.2.1",
+  "version": "1.2.2",
 
   "browser_action": {
     "default_icon": "icon.png",

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
 
   "name": "Zuora Subscription Viewer",
-  "description": "This extension creates a visualisation of a Zuora subscription to aid understanding of what's going on for the customer.",
-  "version": "1.3.0",
+  "description": "This extension creates a visualisation of a Zuora subscription to aid understanding of what has, what is and what will happen for the customer.",
+  "version": "1.4.0",
 
   "browser_action": {
     "default_icon": "icon.png",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "Zuora Subscription Viewer",
-  "description": "This extension creates a visualisation of a Zuora subscription to aid understanding of what has, what is and what will happen for the customer.",
+  "description": "This extension visualises a Zuora subscription to aid understanding of what has, what is and what will happen for the customer.",
   "version": "1.4.0",
 
   "browser_action": {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Zuora Subscription Viewer",
   "description": "This extension creates a visualisation of a Zuora subscription to aid understanding of what's going on for the customer.",
-  "version": "1.2.2",
+  "version": "1.3.0",
 
   "browser_action": {
     "default_icon": "icon.png",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Zuora Subscription Viewer",
   "description": "This extension visualises a Zuora subscription to aid understanding of what has, what is and what will happen for the customer.",
-  "version": "1.4.0",
+  "version": "1.5.1",
 
   "browser_action": {
     "default_icon": "icon.png",

--- a/subscription-viewer.css
+++ b/subscription-viewer.css
@@ -56,6 +56,9 @@ label {
     margin: 0 5px 5px 0;
     padding: 5px;
 }
+#heading {
+    overflow: hidden;
+}
 #details {
     float: left;
     margin-right: 20px;
@@ -122,6 +125,7 @@ label {
 .term0 {
     border: 1px solid green;
     padding-bottom: 1px;
+    min-width: 20px;
 }
 
 .term1 {
@@ -212,12 +216,28 @@ label {
     position: absolute;
 }
 
-.legend date:nth-child(odd) {
+.legend date:nth-child(1n) {
     top: 0;
 }
 
-.legend date:nth-child(even) {
+.legend date:nth-child(2n) {
     top: 1em;
+}
+
+.legend date:nth-child(3n) {
+    top: 2em;
+}
+
+.legend date:nth-child(4n) {
+    top: 3em;
+}
+
+.ticks .today {
+    background-color: cornflowerblue;
+}
+
+.legend .today {
+    color: cornflowerblue
 }
 
 .rpc {

--- a/subscription-viewer.css
+++ b/subscription-viewer.css
@@ -109,7 +109,7 @@ label {
     color: darkorange;
 }
 
-#two-term-grid th {
+#multi-term-grid th {
     line-height: 250%;
 }
 
@@ -117,6 +117,11 @@ label {
     border: 1px;
     overflow: hidden;
     padding: 0;
+}
+
+.term0 {
+    border: 1px solid green;
+    padding-bottom: 1px;
 }
 
 .term1 {

--- a/subscription-viewer.html
+++ b/subscription-viewer.html
@@ -42,7 +42,7 @@
     <section id="visualisation">
         <div id="timeline">
             <h3>Timeline</h3>
-            <table id="two-term-grid">
+            <table id="multi-term-grid">
             </table>
         </div>
         <div id="key">

--- a/subscription-viewer.js
+++ b/subscription-viewer.js
@@ -140,7 +140,8 @@
         const ratePlans = subscription.ratePlans.sort(sortRatePlans);
 
         ratePlans.forEach(function(ratePlan) {
-            if (ratePlan.lastChangeType === "Remove") return;
+            const planHasChargesEndingInThisTermOrNext = ratePlan.ratePlanCharges.map(rpc => moment(rpc.effectiveEndDate)).find(x => x.isAfter(termStartDate));
+            if (ratePlan.lastChangeType === "Remove" && !planHasChargesEndingInThisTermOrNext) return;
 
             const ratePlanCharges = ratePlan.ratePlanCharges.filter(rpc => moment(rpc.effectiveEndDate).diff(moment(rpc.effectiveStartDate), 'days') > 0).sort(sortHomeDeliveryDays);
             ratePlanCharges.forEach(rpc => {

--- a/subscription-viewer.js
+++ b/subscription-viewer.js
@@ -206,7 +206,7 @@
         const currentTermLabel = subscription.status === 'Cancelled' ? 'Final term' : 'Current term';
         const futureTermLabel = subscription.status === 'Cancelled' ? 'Year after cancellation' : subscription.autoRenew ? 'Next term' : 'Renewal term';
 
-        $multiTermGrid.append(`<tr><th class="term0">Last term</th><th class="term1">${currentTermLabel} (<span class="${mechanic.toLowerCase()}">${mechanic}</span>)</th><th class="term2">${futureTermLabel}</th></tr>`);
+        $multiTermGrid.append(`<tr><th class="term0">&hellip;</th><th class="term1">${currentTermLabel} (<span class="${mechanic.toLowerCase()}">${mechanic}</span>)</th><th class="term2">${futureTermLabel}</th></tr>`);
         $multiTermGrid.append($ratePlans).width(preFirstTermLength + currentTermLength + nextTermLength + 3);
         renderLegend($multiTermGrid, earliestRenderDay, notableDates, termEndDate, nextTermEndDate);
     }


### PR DESCRIPTION
Tweak to show removed rate plans if their effective end date is after the current term start date (i.e. they are relevant to this term's context).

Also show a previous term too to properly display rate plans which have ended before the current term starts.

Fixed a bug with grace period.

cc @michaelwmcnamara @AWare @jacobwinch 