### PR TITLE
Next payment date is same or after today

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ subscription-viewer.iml
 subscription-viewer.crx
 subscription-viewer.pem
 cannedDataForTheTrain.js
+archive/*
 Archive.zip
 v1/*

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,11 @@
 
   "name": "Zuora Subscription Viewer",
   "description": "This extension visualises a Zuora subscription to aid understanding of what has, what is and what will happen for the customer.",
+<<<<<<< Updated upstream
   "version": "1.7.8",
+=======
+  "version": "1.8.0",
+>>>>>>> Stashed changes
 
   "browser_action": {
     "default_icon": "icon.png",

--- a/manifest.json
+++ b/manifest.json
@@ -3,12 +3,8 @@
 
   "name": "Zuora Subscription Viewer",
   "description": "This extension visualises a Zuora subscription to aid understanding of what has, what is and what will happen for the customer.",
-<<<<<<< Updated upstream
-  "version": "1.7.8",
-=======
   "version": "1.8.0",
->>>>>>> Stashed changes
-
+  
   "browser_action": {
     "default_icon": "icon.png",
     "default_popup": "subscription-viewer.html"


### PR DESCRIPTION
In cases where there are multiple `chargedThroughDates` take the earliest one that is same or after today. If there is no such date, use old semantics.

**Before**:

![image](https://user-images.githubusercontent.com/13835317/50647402-5ba7fb00-0f70-11e9-9c51-b89155c02c44.png)


**After**:

![image](https://user-images.githubusercontent.com/13835317/50647347-3fa45980-0f70-11e9-8758-6240203f7ae1.png)
